### PR TITLE
Clean up Igniter task implementation

### DIFF
--- a/lib/mix/tasks/claude.install.ex
+++ b/lib/mix/tasks/claude.install.ex
@@ -26,41 +26,16 @@ if Code.ensure_loaded?(Igniter) do
     @impl Igniter.Mix.Task
     def info(_argv, _composing_task) do
       %Igniter.Mix.Task.Info{
-        # Groups allow for overlapping arguments for tasks by the same author
-        # See the generators guide for more.
         group: :claude,
-        # *other* dependencies to add
-        # i.e `{:foo, "~> 2.0"}`
-        adds_deps: [{:claude, "~> 0.1"}],
-        # *other* dependencies to add and call their associated installers, if they exist
-        # i.e `{:foo, "~> 2.0"}`
-        installs: [],
-        # An example invocation
         example: "mix igniter.install claude",
-        # A list of environments that this should be installed in.
-        only: :dev,
-        # a list of positional arguments, i.e `[:file]`
-        positional: [],
-        # Other tasks your task composes using `Igniter.compose_task`, passing in the CLI argv
-        # This ensures your option schema includes options from nested tasks
-        composes: [],
-        # `OptionParser` schema
-        schema: [],
-        # Default values for the options in the `schema`
-        defaults: [],
-        # CLI aliases
-        aliases: [],
-        # A list of options in the schema that are required
-        required: [],
-        # Installer dependency options
+        only: [:dev],
+        composes: ["claude"],
         dep_opts: [runtime: false]
       }
     end
 
     @impl Igniter.Mix.Task
     def igniter(igniter) do
-      # Install the hooks by composing the existing task
-      # This ensures the hooks are properly set up in .claude/settings.json
       igniter
       |> Igniter.compose_task("claude", ["hooks", "install"])
     end


### PR DESCRIPTION
## Summary
- Remove boilerplate comments from Igniter task
- Fix `only` field to use proper list format `[:dev]`
- Add `composes: ["claude"]` to properly declare task composition

## Test plan
- [x] Verify the Igniter task still works with `mix igniter.install claude`
- [x] Ensure the task properly delegates to the base claude task
- [ ] Run tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)