### PR TITLE
Configure RelatedFiles hook to sync documentation

### DIFF
--- a/.claude.exs
+++ b/.claude.exs
@@ -7,7 +7,34 @@
     Claude.Hooks.PostToolUse.ElixirFormatter,
     Claude.Hooks.PostToolUse.CompilationChecker,
     Claude.Hooks.PreToolUse.PreCommitCheck,
-    Claude.Hooks.PostToolUse.RelatedFiles
+    {Claude.Hooks.PostToolUse.RelatedFiles, %{
+      patterns: [
+        # When README updates, check related docs
+        {"README.md", ["CHANGELOG.md", "deps/*/usage-rules.md", "CLAUDE.md"]},
+        
+        # When usage rules update, check README
+        {"deps/*/usage-rules.md", ["README.md", "CLAUDE.md"]},
+        
+        # When CHANGELOG updates, check README for version info
+        {"CHANGELOG.md", "README.md"},
+        
+        # When lib files change, suggest updating tests
+        {"lib/**/*.ex", "test/**/*_test.exs"},
+        
+        # When test files change, suggest checking lib files
+        {"test/**/*_test.exs", "lib/**/*.ex"},
+        
+        # When hooks change, check documentation
+        {"lib/claude/hooks/**/*.ex", ["README.md", "CLAUDE.md"]},
+        
+        # When mix.exs changes (version bumps), check docs
+        {"mix.exs", ["README.md", "CHANGELOG.md"]},
+        
+        # When new features are added, check all docs
+        {"lib/mix/tasks/*.ex", ["README.md", "CLAUDE.md"]},
+        {"lib/claude/*.ex", ["README.md", "CLAUDE.md"]}
+      ]
+    }}
   ],
   subagents: [
     %{

--- a/.claude/hooks/related_files.exs
+++ b/.claude/hooks/related_files.exs
@@ -8,8 +8,27 @@ Mix.install([{:claude, path: "."}, {:jason, "~> 1.4"}, {:igniter, "~> 0.6"}])
 # Read JSON from stdin
 input = IO.read(:stdio, :eof)
 
-# Reuse the existing hook module
-case Claude.Hooks.PostToolUse.RelatedFiles.run(input) do
+# Load user configuration from .claude.exs
+user_config = 
+  case File.read(".claude.exs") do
+    {:ok, content} ->
+      try do
+        {config_map, _} = Code.eval_string(content)
+        # Find the RelatedFiles hook configuration
+        config_map
+        |> Map.get(:hooks, [])
+        |> Enum.find_value(%{}, fn
+          {Claude.Hooks.PostToolUse.RelatedFiles, config} -> config
+          _ -> nil
+        end)
+      rescue
+        _ -> %{}
+      end
+    _ -> %{}
+  end
+
+# Reuse the existing hook module with user configuration
+case Claude.Hooks.PostToolUse.RelatedFiles.run(input, user_config) do
   :ok -> System.halt(0)
   _ -> System.halt(1)
 end


### PR DESCRIPTION
## Summary

- Added custom patterns to the RelatedFiles hook to ensure documentation stays synchronized when files are updated
- Updated the hook module to accept and use user configuration for patterns
- Modified the hook script to load configuration from `.claude.exs`

## Changes

### Hook Configuration
The RelatedFiles hook now monitors these patterns:
- When README updates → suggests checking CHANGELOG, usage rules, and CLAUDE.md
- When usage rules update → suggests checking README and CLAUDE.md  
- When CHANGELOG updates → suggests checking README for version info
- When hooks change → suggests checking documentation
- When mix.exs changes (version bumps) → suggests checking docs
- When new features are added → suggests checking all documentation

### Implementation Details
1. **Updated `.claude.exs`** - Added custom patterns configuration to the RelatedFiles hook
2. **Modified hook module** - Updated to read and use custom patterns from user configuration
3. **Updated hook script** - Added logic to load configuration from `.claude.exs` and pass it to the hook

## Test Plan

- [x] Verified hook configuration loads properly from `.claude.exs`
- [x] Tested that the hook script reads user configuration
- [ ] Test editing README.md triggers suggestions for related docs
- [ ] Test editing mix.exs triggers suggestions for README and CHANGELOG
- [ ] Test editing hook files triggers documentation suggestions

🤖 Generated with [Claude Code](https://claude.ai/code)