### PR TITLE
Fix infinite loop in CI when stop hooks with blocking?: false fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Webhook reporters now correctly receive hook events during execution
+- Stop hooks with all non-blocking failures now exit with code 0 to prevent infinite loops in CI
 
 ## [0.5.1] - 2025-08-22
 


### PR DESCRIPTION
## Summary

Fixes the CI timeout issue where Claude Code Review was getting stuck in an infinite loop acknowledging stop hook feedback.

## Root Cause

When stop hooks with `blocking?: false` failed, the script was still exiting with non-zero codes. Claude Code interprets any non-zero exit from stop hooks as needing attention, causing it to repeatedly acknowledge the feedback in an infinite loop.

## Solution

When ALL failed stop/subagent_stop hooks have `blocking?: false`, the script now exits with code 0 instead of the max exit code. This signals success to Claude Code while still displaying the informational failure messages.

## Test Plan

- [x] Added failing test that reproduces the bug
- [x] Implemented fix to make test pass
- [x] Updated existing test expectations to match new behavior
- [x] Added test for mixed blocking/non-blocking scenarios
- [x] All tests pass (280 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.ai/code)