### PR TITLE
Add ExDoc plugin for pre-commit documentation generation

### DIFF
--- a/.claude.exs
+++ b/.claude.exs
@@ -2,8 +2,9 @@
   plugins: [
     Claude.Plugins.Base,
     Claude.Plugins.ClaudeCode,
-    Claude.Plugins.Logging,
-    {Claude.Plugins.Credo, strict?: true}
+    {Claude.Plugins.Credo, strict?: true},
+    Claude.Plugins.ExDoc,
+    Claude.Plugins.Logging
   ],
   hooks: %{
     pre_tool_use: [

--- a/lib/claude/documentation.ex
+++ b/lib/claude/documentation.ex
@@ -38,7 +38,7 @@ defmodule Claude.Documentation do
   @doc """
   Process documentation references for content.
 
-  This is the main entry point used by `Claude.NestedMemories`.
+  This is the main entry point used by Claude.NestedMemories.
   Takes existing content and a list of documentation references,
   then updates the content with the new documentation section.
 

--- a/lib/claude/plugins/ex_doc.ex
+++ b/lib/claude/plugins/ex_doc.ex
@@ -1,0 +1,31 @@
+defmodule Claude.Plugins.ExDoc do
+  @moduledoc """
+  ExDoc plugin for Claude Code providing documentation generation on pre-commit.
+
+  This plugin automatically runs `mix docs` before git commits to ensure documentation
+  is generated and up-to-date.
+
+  ## Usage
+
+  Add to your `.claude.exs`:
+
+      %{
+        plugins: [Claude.Plugins.ExDoc]
+      }
+
+  This will run `mix docs` before every git commit.
+  """
+
+  @behaviour Claude.Plugin
+
+  @impl Claude.Plugin
+  def config(_opts) do
+    %{
+      hooks: %{
+        pre_tool_use: [
+          {"docs --warnings-as-errors", when: "Bash", command: ~r/^git commit/}
+        ]
+      }
+    }
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a new opt-in ExDoc plugin that runs `mix docs --warnings-as-errors` before git commits
- Ensures documentation quality by blocking commits when there are documentation warnings or errors
- Fixes an existing documentation warning about referencing the hidden Claude.NestedMemories module

## Features
The ExDoc plugin:
- Runs automatically before `git commit` commands when enabled
- Uses `--warnings-as-errors` flag to catch documentation issues
- Is completely opt-in - must be explicitly added to `.claude.exs` configuration
- Follows the same pattern as other Claude plugins (like Credo)

## Usage
To enable the plugin, add it to your `.claude.exs`:

```elixir
%{
  plugins: [Claude.Plugins.ExDoc]
}
```

## Test plan
- [x] Plugin loads successfully with `Claude.Plugin.load_plugin(Claude.Plugins.ExDoc)`
- [x] Documentation builds without warnings after fixing the Claude.NestedMemories reference
- [x] Plugin correctly blocks commits when documentation has warnings
- [x] Plugin allows commits when documentation is clean

🤖 Generated with [Claude Code](https://claude.ai/code)