### PR TITLE
Remove duplicate test directory setup in hooks run test

### DIFF
--- a/test/mix/tasks/claude.hooks.run_test.exs
+++ b/test/mix/tasks/claude.hooks.run_test.exs
@@ -5,7 +5,6 @@ defmodule Mix.Tasks.Claude.Hooks.RunTest do
   alias Mix.Tasks.Claude.Hooks.Run
 
   setup :verify_on_exit!
-  setup :setup_test_directory
   setup :stub_system_calls
 
   setup do


### PR DESCRIPTION
## Summary
- avoid double test directory initialization in Mix.Tasks.Claude.Hooks.RunTest by dropping redundant `setup_test_directory` call

## Testing
- `mix test test/mix/tasks/claude.hooks.run_test.exs --warnings-as-errors`
- `mix test --warnings-as-errors`


------
https://chatgpt.com/codex/tasks/task_e_68c1a75b47d88330ad2108b5b02c5294