### PR TITLE
Auto format code in default hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Run `mix claude.install` after updating to apply changes.
 This library leverages [Claude Code's hook system](https://docs.anthropic.com/en/docs/claude-code/hooks) to provide validation at appropriate times:
 
 1. **Claude edits a file** → PostToolUse hook triggered immediately
-2. **Hook runs Mix tasks** → `mix format --check-formatted`, `mix compile --warnings-as-errors`
+2. **Hook runs Mix tasks** → `mix format`, `mix compile --warnings-as-errors`
 3. **Feedback provided** → Claude sees any issues and can fix them
 4. **Process repeats** → Until the code is production-ready
 

--- a/cheatsheets/hooks.cheatmd
+++ b/cheatsheets/hooks.cheatmd
@@ -20,6 +20,7 @@ If you need blocking behavior for stop hooks, explicitly set `blocking?: true` b
 }
 ```
 
+
 ## Atom Shortcuts
 
 ### `:compile` - Compilation Checking
@@ -40,21 +41,21 @@ post_tool_use: [:compile]  # Auto-filters: :write, :edit, :multi_edit
 pre_tool_use: [:compile]   # Auto-filters: git commit commands
 ```
 
-### `:format` - Format Checking
+### `:format` - Auto Formatting
 
-Runs `mix format --check-formatted` (checks only, doesn't auto-format).
+Runs `mix format` to automatically format code.
 
 ```elixir
-# Check formatting when Claude finishes
+# Format code when Claude finishes
 stop: [:format]
 
-# Check formatting after sub-agents
+# Format code after sub-agents
 subagent_stop: [:format]
 
-# Check specific file after editing
+# Format specific file after editing
 post_tool_use: [:format]  # Uses {{tool_input.file_path}}
 
-# Check formatting before commits
+# Format code before commits
 pre_tool_use: [:format]   # Auto-filters: git commit commands
 ```
 
@@ -83,10 +84,10 @@ pre_tool_use: [:unused_deps]
 
 | Event | Expands To | Description |
 |-------|------------|-------------|
-| `:stop` | `"format --check-formatted"` | Check all files |
-| `:subagent_stop` | `"format --check-formatted"` | Check all files |
-| `:post_tool_use` | `{"format --check-formatted {{tool_input.file_path}}", when: [:write, :edit, :multi_edit]}` | Check modified file |
-| `:pre_tool_use` | `{"format --check-formatted", when: "Bash", command: ~r/^git commit/}` | Check all before commit |
+| `:stop` | `"format"` | Format all files |
+| `:subagent_stop` | `"format"` | Format all files |
+| `:post_tool_use` | `{"format {{tool_input.file_path}}", when: [:write, :edit, :multi_edit]}` | Format modified file |
+| `:pre_tool_use` | `{"format", when: "Bash", command: ~r/^git commit/}` | Format all before commit |
 
 ### `:unused_deps` Expansions
 
@@ -348,7 +349,7 @@ session_start: [
     stop: [
       # Run all checks, stop on first failure
       {"compile --warnings-as-errors", halt_pipeline?: true},
-      {"format --check-formatted", halt_pipeline?: true},
+      {"format", halt_pipeline?: true},
       {"test", halt_pipeline?: true},
       {"credo --strict", halt_pipeline?: true},
       {"dialyzer", halt_pipeline?: true}
@@ -508,7 +509,7 @@ claude --debug
   hooks: %{
     stop: [
       {"compile --all-warnings", halt_pipeline?: true},
-      {"format --check-formatted", halt_pipeline?: true},
+      {"format", halt_pipeline?: true},
       {"test --cover", halt_pipeline?: true},
       {"credo --strict", halt_pipeline?: true},
       {"dialyzer", halt_pipeline?: true},

--- a/documentation/guide-hooks.md
+++ b/documentation/guide-hooks.md
@@ -27,7 +27,7 @@ When you run `mix igniter.install claude`, it automatically sets up default hook
 ```
 
 This provides:
-1. **Immediate validation** - Checks formatting and compilation after file edits
+1. **Immediate validation** - Formats code and checks compilation after file edits
 2. **Pre-commit validation** - Ensures clean code before commits, including unused dependency checks
 
 ## Available Hook Atoms
@@ -37,7 +37,7 @@ Claude provides these atom shortcuts that expand to full hook configurations:
 ### Available Hooks
 - **`:compile`** - Runs `mix compile --warnings-as-errors` with `halt_pipeline?: true` (stops on failure)
   - For `stop`/`subagent_stop`: Uses `blocking?: false` to prevent infinite loops
-- **`:format`** - Runs `mix format --check-formatted` (checks only, doesn't auto-format)
+- **`:format`** - Runs `mix format` to automatically format code
   - For `stop`/`subagent_stop`: Uses `blocking?: false` to prevent infinite loops
 - **`:unused_deps`** - Runs `mix deps.unlock --check-unused` (pre_tool_use on git commits only)
 
@@ -65,7 +65,7 @@ Different hook events run at different times:
 ### What Makes a Good Hook
 
 ✅ **Good hook operations:**
-- Format checking with `mix format --check-formatted`
+- Auto-formatting with `mix format`
 - Compilation with `mix compile --warnings-as-errors`
 - Simple logging or metrics collection
 - Read-only operations that provide context

--- a/lib/claude/hooks/defaults.ex
+++ b/lib/claude/hooks/defaults.ex
@@ -38,16 +38,16 @@ defmodule Claude.Hooks.Defaults do
          when: "Bash", command: ~r/^git commit/, halt_pipeline?: true}
 
       {:format, :stop} ->
-        {"format --check-formatted", blocking?: false}
+        {"format", blocking?: false}
 
       {:format, :subagent_stop} ->
-        {"format --check-formatted", blocking?: false}
+        {"format", blocking?: false}
 
       {:format, :post_tool_use} ->
-        {"format --check-formatted {{tool_input.file_path}}", when: [:write, :edit, :multi_edit]}
+        {"format {{tool_input.file_path}}", when: [:write, :edit, :multi_edit]}
 
       {:format, :pre_tool_use} ->
-        {"format --check-formatted", when: "Bash", command: ~r/^git commit/}
+        {"format", when: "Bash", command: ~r/^git commit/}
 
       {:unused_deps, :pre_tool_use} ->
         {"deps.unlock --check-unused", when: "Bash", command: ~r/^git commit/}

--- a/lib/mix/tasks/claude.gen.subagent.ex
+++ b/lib/mix/tasks/claude.gen.subagent.ex
@@ -423,7 +423,7 @@ defmodule Mix.Tasks.Claude.Gen.Subagent do
       "        id: :elixir_quality_checks,\n" <>
       "        matcher: [:write, :edit, :multi_edit],\n" <>
       "        tasks: [\n" <>
-      "          \"format --check-formatted {{tool_input.file_path}}\",\n" <>
+      "          \"format {{tool_input.file_path}}\",\n" <>
       "          \"compile --warnings-as-errors\"\n" <>
       "        ]\n" <>
       "      }\n" <>

--- a/test/claude/hooks/defaults_test.exs
+++ b/test/claude/hooks/defaults_test.exs
@@ -27,23 +27,22 @@ defmodule Claude.Hooks.DefaultsTest do
 
     test "expands :format atom for stop event" do
       assert Defaults.expand_hook(:format, :stop) ==
-               {"format --check-formatted", blocking?: false}
+               {"format", blocking?: false}
     end
 
     test "expands :format atom for subagent_stop event" do
       assert Defaults.expand_hook(:format, :subagent_stop) ==
-               {"format --check-formatted", blocking?: false}
+               {"format", blocking?: false}
     end
 
     test "expands :format atom for post_tool_use event" do
       assert Defaults.expand_hook(:format, :post_tool_use) ==
-               {"format --check-formatted {{tool_input.file_path}}",
-                when: [:write, :edit, :multi_edit]}
+               {"format {{tool_input.file_path}}", when: [:write, :edit, :multi_edit]}
     end
 
     test "expands :format atom for pre_tool_use event" do
       assert Defaults.expand_hook(:format, :pre_tool_use) ==
-               {"format --check-formatted", when: "Bash", command: ~r/^git commit/}
+               {"format", when: "Bash", command: ~r/^git commit/}
     end
 
     test "expands :unused_deps atom for pre_tool_use event" do
@@ -79,7 +78,7 @@ defmodule Claude.Hooks.DefaultsTest do
       expanded = Defaults.expand_hook(hook, :stop)
 
       assert expanded ==
-               {"format --check-formatted", [env: %{"MIX_ENV" => "dev"}, blocking?: false]}
+               {"format", [env: %{"MIX_ENV" => "dev"}, blocking?: false]}
     end
 
     test "expands atom with options for post_tool_use preserving existing options" do
@@ -114,7 +113,7 @@ defmodule Claude.Hooks.DefaultsTest do
 
       assert expanded == [
                {"compile --warnings-as-errors", halt_pipeline?: true, blocking?: false},
-               {"format --check-formatted", blocking?: false}
+               {"format", blocking?: false}
              ]
     end
 
@@ -126,7 +125,7 @@ defmodule Claude.Hooks.DefaultsTest do
       assert expanded == [
                {"compile --warnings-as-errors", halt_pipeline?: true, blocking?: false},
                "custom task",
-               {"format --check-formatted", blocking?: false, when: [:write]}
+               {"format", blocking?: false, when: [:write]}
              ]
     end
 
@@ -147,8 +146,7 @@ defmodule Claude.Hooks.DefaultsTest do
                   halt_pipeline?: true,
                   env: %{"MIX_ENV" => "test"}
                 ]},
-               {"format --check-formatted",
-                [when: "Bash", command: ~r/^git commit/, blocking?: false]},
+               {"format", [when: "Bash", command: ~r/^git commit/, blocking?: false]},
                {"deps.unlock --check-unused", when: "Bash", command: ~r/^git commit/}
              ]
     end
@@ -199,26 +197,26 @@ defmodule Claude.Hooks.DefaultsTest do
       env = %{"MIX_ENV" => "dev"}
 
       # stop event - format returns simple string, env should be added as options
-      assert {"format --check-formatted", opts} =
+      assert {"format", opts} =
                Defaults.expand_hook({:format, env: env}, :stop)
 
       assert opts[:env] == env
 
       # subagent_stop event
-      assert {"format --check-formatted", opts} =
+      assert {"format", opts} =
                Defaults.expand_hook({:format, env: env}, :subagent_stop)
 
       assert opts[:env] == env
 
       # post_tool_use event
-      assert {"format --check-formatted {{tool_input.file_path}}", opts} =
+      assert {"format {{tool_input.file_path}}", opts} =
                Defaults.expand_hook({:format, env: env}, :post_tool_use)
 
       assert opts[:env] == env
       assert opts[:when] == [:write, :edit, :multi_edit]
 
       # pre_tool_use event
-      assert {"format --check-formatted", opts} =
+      assert {"format", opts} =
                Defaults.expand_hook({:format, env: env}, :pre_tool_use)
 
       assert opts[:env] == env
@@ -249,7 +247,7 @@ defmodule Claude.Hooks.DefaultsTest do
 
       assert [
                {"compile --warnings-as-errors", compile_opts},
-               {"format --check-formatted", format_opts},
+               {"format", format_opts},
                {"deps.unlock --check-unused", deps_opts}
              ] = expanded
 

--- a/test/mix/tasks/claude.hooks.run_env_test.exs
+++ b/test/mix/tasks/claude.hooks.run_env_test.exs
@@ -133,7 +133,7 @@ defmodule Mix.Tasks.Claude.Hooks.RunEnvTest do
       config = %{
         hooks: %{
           stop: [
-            "format --check-formatted"
+            "format"
           ]
         }
       }
@@ -155,7 +155,7 @@ defmodule Mix.Tasks.Claude.Hooks.RunEnvTest do
         task_runner: task_runner
       )
 
-      assert_received {:task_executed, "format", ["--check-formatted"], %{}}
+      assert_received {:task_executed, "format", [], %{}}
     end
 
     test "env vars work with cmd prefix" do

--- a/test/mix/tasks/claude.hooks.run_test.exs
+++ b/test/mix/tasks/claude.hooks.run_test.exs
@@ -90,7 +90,7 @@ defmodule Mix.Tasks.Claude.Hooks.RunTest do
         task_runner: task_runner
       )
 
-      assert_received {:mix_task_run, "format", ["--check-formatted", "lib/test.ex"]}
+      assert_received {:mix_task_run, "format", ["lib/test.ex"]}
     end
 
     test "expands multiple atoms in pre_tool_use for git commit" do
@@ -120,7 +120,7 @@ defmodule Mix.Tasks.Claude.Hooks.RunTest do
       )
 
       assert_received {:mix_task_run, "compile", ["--warnings-as-errors"]}
-      assert_received {:mix_task_run, "format", ["--check-formatted"]}
+      assert_received {:mix_task_run, "format", []}
       assert_received {:mix_task_run, "deps.unlock", ["--check-unused"]}
     end
 
@@ -196,7 +196,7 @@ defmodule Mix.Tasks.Claude.Hooks.RunTest do
       config = %{
         hooks: %{
           pre_tool_use: [
-            {"format --check-formatted", when: "Write"}
+            {"format", when: "Write"}
           ]
         }
       }
@@ -220,7 +220,7 @@ defmodule Mix.Tasks.Claude.Hooks.RunTest do
         task_runner: task_runner
       )
 
-      assert_received {:task_executed, "format", ["--check-formatted"]}
+      assert_received {:task_executed, "format", []}
     end
 
     test "provides helpful error message for non-existent Mix tasks" do
@@ -577,7 +577,7 @@ defmodule Mix.Tasks.Claude.Hooks.RunTest do
       config = %{
         hooks: %{
           post_tool_use: [
-            "format --check-formatted {{tool_input.file_path}}"
+            "format {{tool_input.file_path}}"
           ]
         }
       }
@@ -600,7 +600,7 @@ defmodule Mix.Tasks.Claude.Hooks.RunTest do
         task_runner: task_runner
       )
 
-      assert_received {:mix_task_run, "format", ["--check-formatted", "lib/test.ex"]}
+      assert_received {:mix_task_run, "format", ["lib/test.ex"]}
     end
 
     test "template interpolation handles nested paths", _context do

--- a/test/mix/tasks/claude.install_test.exs
+++ b/test/mix/tasks/claude.install_test.exs
@@ -989,7 +989,7 @@ defmodule Mix.Tasks.Claude.InstallTest do
             %{
               hooks: %{
                 post_tool_use: [
-                  {"format --check-formatted {{tool_input.file_path}}", when: [:write, :edit]}
+                  {"format {{tool_input.file_path}}", when: [:write, :edit]}
                 ]
               }
             }
@@ -1234,7 +1234,7 @@ defmodule Mix.Tasks.Claude.InstallTest do
             %{
               hooks: %{
                 post_tool_use: [
-                  {"format --check-formatted {{tool_input.file_path}}", when: [:write, :edit]},
+                  {"format {{tool_input.file_path}}", when: [:write, :edit]},
                   {"compile --warnings-as-errors", when: [:write, :edit, :multi_edit]}
                 ],
                 pre_tool_use: [

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -44,7 +44,7 @@ Claude supports all Claude Code hook events:
 ### Available Hook Atoms
 
 - `:compile` - Runs `mix compile --warnings-as-errors` with `halt_pipeline?: true`
-- `:format` - Runs `mix format --check-formatted` (checks only, doesn't auto-format)
+- `:format` - Runs `mix format` to automatically format code
 - `:unused_deps` - Runs `mix deps.unlock --check-unused` (pre_tool_use on git commits only)
 
 **Note**: Stop hooks (`stop`, `subagent_stop`) are not included in defaults due to notification stacking risks. They remain available for opt-in use but should only be used for simple operations that rarely fail.


### PR DESCRIPTION
## Summary
- Run `mix format` in default hooks to auto-format files
- Update documentation and tests for new formatting behavior

## Testing
- `mix format`
- `mix test`

closes https://github.com/bradleygolden/claude/issues/148

------
https://chatgpt.com/codex/tasks/task_e_68c2eed7ec888330a7f0354b008b6f9e