### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 # Claude Code Plugins for Elixir
 
+[![Run in Smithery](https://smithery.ai/badge/skills/bradleygolden)](https://smithery.ai/skills?ns=bradleygolden&utm_source=github&utm_medium=badge)
+
+
 Unofficial Claude Code plugin marketplace for Elixir and BEAM ecosystem development.
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)


### PR DESCRIPTION
## Add skill discoverability badge

Your 5 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Claude Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/bradleygolden)](https://smithery.ai/skills?ns=bradleygolden&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.